### PR TITLE
feat: real-time podcast progress UI with SSE and topics input

### DIFF
--- a/src/components/agent/KnowledgeConfigurationForm.jsx
+++ b/src/components/agent/KnowledgeConfigurationForm.jsx
@@ -86,7 +86,7 @@ const KNOWLEDGE_PRESETS = [
   }
 ];
 
-const KnowledgeConfigurationForm = ({ config, onChange, agentType = 'qa' }) => {
+const KnowledgeConfigurationForm = ({ config, onChange, agentType = 'qa', maxContextTokensLimit = 128000 }) => {
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [selectedPreset, setSelectedPreset] = useState('custom');
 
@@ -244,14 +244,14 @@ const KnowledgeConfigurationForm = ({ config, onChange, agentType = 'qa' }) => {
               <input
                 type="number"
                 min="1000"
-                max="32000"
+                max={maxContextTokensLimit}
                 step="1000"
                 value={currentConfig.max_context_tokens}
                 onChange={(e) => handleChange('max_context_tokens', parseInt(e.target.value))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
               <p className="text-xs text-gray-500 mt-1">
-                Maximum tokens for document context
+                Maximum tokens for document context (model max: {maxContextTokensLimit.toLocaleString()})
               </p>
             </div>
 

--- a/src/components/collaboration/Comments.jsx
+++ b/src/components/collaboration/Comments.jsx
@@ -39,15 +39,19 @@ const Comments = ({ resourceId, resourceType = 'notebook', conversationId }) => 
   const [editContent, setEditContent] = useState('');
   const [openMenuId, setOpenMenuId] = useState(null);
 
+  // Only subscribe to SSE and fetch comments for notebook resources
+  // Other resource types (agent, workflow, etc.) don't have backend comment endpoints yet
+  const isNotebook = resourceType === 'notebook';
+
   // Subscribe to real-time SSE updates
-  useCommentSSE(resourceId);
+  useCommentSSE(isNotebook ? resourceId : null);
 
   // Fetch comments on mount / resource change
   useEffect(() => {
-    if (resourceId) {
+    if (resourceId && isNotebook) {
       dispatch(fetchComments({ notebookId: resourceId, conversationId }));
     }
-  }, [dispatch, resourceId, conversationId]);
+  }, [dispatch, resourceId, conversationId, isNotebook]);
 
   const currentUser = user ? {
     id: user.id || user.sub,

--- a/src/components/modals/AgentCreateModal.jsx
+++ b/src/components/modals/AgentCreateModal.jsx
@@ -110,15 +110,19 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
   // Per-skill connection overrides: { skillName: { connectionId, serverId } }
   const [skillConnections, setSkillConnections] = useState({});
 
-  // Fetch available skills
+  // Fetch available skills (use mocks until backend skills endpoint exists)
   useEffect(() => {
     if (!isOpen) return;
     const fetchSkills = async () => {
       try {
         setLoadingSkills(true);
-        const response = await api.skills.list();
-        const skillList = response.skills || response || [];
-        setAvailableSkills(Array.isArray(skillList) ? skillList : []);
+        if (api.skills && typeof api.skills.list === 'function') {
+          const response = await api.skills.list();
+          const skillList = response.skills || response || [];
+          setAvailableSkills(Array.isArray(skillList) ? skillList : []);
+        } else {
+          setAvailableSkills(mockSkills);
+        }
       } catch (err) {
         console.warn('[AgentCreate] Failed to fetch skills, using mocks:', err);
         setAvailableSkills(mockSkills);
@@ -456,8 +460,8 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
       errors.temperature = 'Temperature must be between 0 and 1';
     }
 
-    if (formData.llm_config.max_tokens < 1 || formData.llm_config.max_tokens > 32000) {
-      errors.max_tokens = 'Max tokens must be between 1 and 32000';
+    if (formData.llm_config.max_tokens < 1 || formData.llm_config.max_tokens > maxTokensLimit) {
+      errors.max_tokens = `Max tokens must be between 1 and ${maxTokensLimit.toLocaleString()}`;
     }
 
     return errors;
@@ -511,6 +515,7 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
       const agentData = {
         ...formData,
         type: formData.type || 'qa', // Explicitly ensure type is included
+        tags: (formData.tags || []).filter(t => t && t.trim()), // Strip empty tags
         skills: effectiveSkills, // Include both explicit and auto-detected skills
         skill_connections: Object.keys(skillConnections).length > 0 ? skillConnections : undefined,
         space_id: currentSpace.space_id
@@ -565,6 +570,18 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
       availableModels = selectedProvider.models;
     }
   }
+
+  // Look up the selected model's capabilities from the router data
+  const selectedModel = availableModels.find(m => {
+    const mName = typeof m === 'string' ? m : (m.id || m.name);
+    return mName === formData.llm_config.model;
+  });
+  const selectedModelMaxOutputTokens = (typeof selectedModel === 'object' && selectedModel?.max_output_tokens) || null;
+  const selectedModelMaxContextWindow = (typeof selectedModel === 'object' && selectedModel?.max_context_window) || null;
+  // For the max_tokens input: use model's max_output_tokens if available, otherwise a generous fallback
+  const maxTokensLimit = selectedModelMaxOutputTokens || 128000;
+  // For the knowledge config max_context_tokens: use model's max_context_window if available
+  const maxContextTokensLimit = selectedModelMaxContextWindow || 128000;
 
   return (
     <Modal
@@ -769,7 +786,7 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
                 type="number"
                 min="0"
                 max="1"
-                step="0.1"
+                step="0.05"
                 value={formData.llm_config.temperature}
                 onChange={(e) => handleLLMConfigChange('temperature', parseFloat(e.target.value))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-(--color-primary-500) focus:border-(--color-primary-500)"
@@ -779,11 +796,14 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-2">
                 Max Tokens
+                {selectedModelMaxOutputTokens && (
+                  <span className="text-xs text-gray-400 ml-1">(max {selectedModelMaxOutputTokens.toLocaleString()})</span>
+                )}
               </label>
               <input
                 type="number"
                 min="1"
-                max="32000"
+                max={maxTokensLimit}
                 value={formData.llm_config.max_tokens}
                 onChange={(e) => handleLLMConfigChange('max_tokens', parseInt(e.target.value))}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-(--color-primary-500) focus:border-(--color-primary-500)"
@@ -920,6 +940,7 @@ const AgentCreateModal = ({ isOpen, onClose, agent, onCreateAgent, onUpdateAgent
                   }}
                   onChange={handleKnowledgeConfigChange}
                   agentType={formData.type}
+                  maxContextTokensLimit={maxContextTokensLimit}
                 />
               </div>
             )}

--- a/src/components/notebooks/ProducerExecutionModal.jsx
+++ b/src/components/notebooks/ProducerExecutionModal.jsx
@@ -5,7 +5,9 @@ import {
   selectExecutionState,
   clearExecutionState,
   selectProducerPreferences,
+  selectProductionProgress,
 } from '../../store/slices/producersSlice.js';
+import { useProductionProgress } from '../../hooks/useProductionProgress.js';
 import { api } from '../../services/api.js';
 import RendererSelectModal from './RendererSelectModal.jsx';
 import {
@@ -123,6 +125,17 @@ const ProducerExecutionModal = ({
   ]);
   const [voiceMapping, setVoiceMapping] = useState({});
   const [podcastDuration, setPodcastDuration] = useState(10);
+  const [podcastTopics, setPodcastTopics] = useState('');
+
+  // Track production progress for podcast productions via SSE
+  const productionId = executionState.production?.id;
+  const isPodcast = productionType === 'podcast';
+  const progress = useAppSelector(state =>
+    productionId ? selectProductionProgress(state, productionId) : null
+  );
+  useProductionProgress(productionId, {
+    enabled: isPodcast && !!productionId && executionState.status !== 'failed',
+  });
 
   // Initialize production type based on selected producer
   useEffect(() => {
@@ -222,6 +235,9 @@ const ProducerExecutionModal = ({
         context.tts_provider = ttsProvider;
         context.speakers = speakers;
         context.podcast_duration = podcastDuration;
+        if (podcastTopics.trim()) {
+          context.topics = podcastTopics.trim();
+        }
         // Only send voice_mapping entries that have non-empty values
         const filteredMapping = Object.fromEntries(
           Object.entries(voiceMapping).filter(([, v]) => v && v.length > 0)
@@ -263,7 +279,7 @@ const ProducerExecutionModal = ({
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4">
+      <div className="bg-white rounded-xl shadow-xl w-full max-w-lg mx-4 max-h-[90vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
           <div className="flex items-center gap-3">
@@ -285,7 +301,7 @@ const ProducerExecutionModal = ({
         </div>
 
         {/* Content */}
-        <div className="p-6 space-y-5">
+        <div className="p-6 space-y-5 overflow-y-auto flex-1">
           {/* Title */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -457,6 +473,18 @@ const ProducerExecutionModal = ({
                   />
                 </div>
                 <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Topics (optional)</label>
+                  <textarea
+                    value={podcastTopics}
+                    onChange={(e) => setPodcastTopics(e.target.value)}
+                    disabled={isExecuting || hasCompleted}
+                    placeholder="e.g., focus on water conservation policies, compare urban vs rural approaches"
+                    rows={2}
+                    className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:ring-1 focus:ring-(--color-primary-500) disabled:bg-gray-100 resize-none"
+                  />
+                  <p className="text-xs text-gray-400 mt-0.5">Guide the podcast to focus on specific topics from the documents</p>
+                </div>
+                <div>
                   <label className="block text-xs font-medium text-gray-600 mb-1">
                     Duration: {podcastDuration} min
                   </label>
@@ -507,13 +535,14 @@ const ProducerExecutionModal = ({
                 {isExecuting && <Loader2 size={20} className="text-blue-600 animate-spin" />}
                 {hasCompleted && <CheckCircle size={20} className="text-green-600" />}
                 {hasFailed && <XCircle size={20} className="text-red-600" />}
-                <div>
+                <div className="flex-1">
                   <p className={`font-medium ${
                     isExecuting ? 'text-blue-800' :
                     hasCompleted ? 'text-green-800' :
                     'text-red-800'
                   }`}>
-                    {isExecuting && 'Executing producer...'}
+                    {isExecuting && !progress && 'Executing producer...'}
+                    {isExecuting && progress && (progress.message || `Phase: ${progress.phase}`)}
                     {hasCompleted && 'Production completed!'}
                     {hasFailed && 'Execution failed'}
                   </p>
@@ -522,6 +551,37 @@ const ProducerExecutionModal = ({
                   )}
                 </div>
               </div>
+
+              {/* Progress bar for podcast generation */}
+              {isPodcast && progress && progress.clipsTotal > 0 && (
+                <div className="mt-3">
+                  <div className="flex items-center justify-between text-xs text-blue-700 mb-1">
+                    <span>
+                      {progress.phase === 'tts_generating' && `Generating clip ${progress.clipsCompleted}/${progress.clipsTotal}`}
+                      {progress.phase === 'assembling' && 'Assembling audio...'}
+                      {progress.phase === 'uploading' && 'Uploading...'}
+                      {progress.phase === 'completed' && 'Done!'}
+                    </span>
+                    <span>{progress.phase === 'completed' ? 100 : Math.round((progress.clipsCompleted / progress.clipsTotal) * 100)}%</span>
+                  </div>
+                  <div className="w-full bg-blue-200 rounded-full h-2">
+                    <div
+                      className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                      style={{
+                        width: `${progress.phase === 'completed' ? 100 :
+                          progress.phase === 'uploading' ? 95 :
+                          progress.phase === 'assembling' ? 85 :
+                          Math.round((progress.clipsCompleted / progress.clipsTotal) * 80)}%`,
+                      }}
+                    />
+                  </div>
+                  {progress.clipsFailed > 0 && (
+                    <p className="text-xs text-amber-600 mt-1">
+                      {progress.clipsFailed} clip{progress.clipsFailed > 1 ? 's' : ''} failed
+                    </p>
+                  )}
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/src/components/notebooks/ProductionViewer.jsx
+++ b/src/components/notebooks/ProductionViewer.jsx
@@ -4,7 +4,10 @@ import {
   fetchProductionContent,
   selectProductionContent,
   deleteProduction,
+  retryProduction,
+  selectProductionProgress,
 } from '../../store/slices/producersSlice.js';
+import { useProductionProgress } from '../../hooks/useProductionProgress.js';
 import {
   X,
   Download,
@@ -22,6 +25,7 @@ import {
   Loader2,
   AlertTriangle,
   ExternalLink,
+  RotateCcw,
 } from 'lucide-react';
 
 const FORMAT_ICONS = {
@@ -52,6 +56,7 @@ const ProductionViewer = ({
   const [copied, setCopied] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [retrying, setRetrying] = useState(false);
 
   // Get refreshed production from store (may have updated mediaUrl after async rendering)
   const storeProduction = useAppSelector(state => {
@@ -70,14 +75,30 @@ const ProductionViewer = ({
   const contentLoading = contentState?.loading;
   const contentError = contentState?.error;
 
+  // Production progress (for queued/rendering productions)
+  const isInProgress = production && ['queued', 'rendering', 'retrying'].includes(production.status);
+  const progress = useAppSelector(state =>
+    production ? selectProductionProgress(state, production.id) : null
+  );
+  useProductionProgress(production?.id, { enabled: isOpen && isInProgress });
+
+  // Track whether we've already fetched for this production to prevent infinite re-fetch loops
+  const [fetchedId, setFetchedId] = useState(null);
+
   // Fetch content when modal opens
-  // Always re-fetch if production has a renderer but no mediaUrl yet (async render may have completed)
-  const needsRefresh = production?.rendererId && !production?.mediaUrl;
   useEffect(() => {
-    if (isOpen && production && (!content || needsRefresh) && !contentLoading) {
+    if (isOpen && production && !contentLoading && production.id !== fetchedId) {
+      setFetchedId(production.id);
       dispatch(fetchProductionContent(production.id));
     }
-  }, [isOpen, production, content, contentLoading, needsRefresh, dispatch]);
+  }, [isOpen, production?.id, contentLoading, fetchedId, dispatch]);
+
+  // Reset fetchedId when modal closes so re-opening triggers a fresh fetch
+  useEffect(() => {
+    if (!isOpen) {
+      setFetchedId(null);
+    }
+  }, [isOpen]);
 
   // Reset copy state
   useEffect(() => {
@@ -135,6 +156,18 @@ const ProductionViewer = ({
     } finally {
       setDeleting(false);
       setShowDeleteConfirm(false);
+    }
+  };
+
+  const handleRetry = async () => {
+    if (!production || !notebookId) return;
+    setRetrying(true);
+    try {
+      await dispatch(retryProduction({ productionId: production.id, notebookId }));
+    } catch (err) {
+      console.error('Failed to retry production:', err);
+    } finally {
+      setRetrying(false);
     }
   };
 
@@ -244,6 +277,62 @@ const ProductionViewer = ({
             </div>
           )}
         </div>
+
+        {/* Progress indicator for in-progress productions */}
+        {isInProgress && (
+          <div className="px-6 py-3 bg-blue-50 border-b border-blue-200">
+            <div className="flex items-center gap-3 mb-2">
+              <Loader2 size={18} className="text-blue-600 animate-spin" />
+              <span className="text-sm font-medium text-blue-800">
+                {progress?.message || `Status: ${production.status}`}
+              </span>
+            </div>
+            {progress && progress.clipsTotal > 0 && (
+              <div>
+                <div className="flex items-center justify-between text-xs text-blue-700 mb-1">
+                  <span>
+                    {progress.phase === 'tts_generating' && `Generating clip ${progress.clipsCompleted}/${progress.clipsTotal}`}
+                    {progress.phase === 'assembling' && 'Assembling audio...'}
+                    {progress.phase === 'uploading' && 'Uploading...'}
+                  </span>
+                  <span>{progress.phase === 'completed' ? 100 : Math.round((progress.clipsCompleted / progress.clipsTotal) * 100)}%</span>
+                </div>
+                <div className="w-full bg-blue-200 rounded-full h-2">
+                  <div
+                    className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                    style={{
+                      width: `${progress.phase === 'uploading' ? 95 :
+                        progress.phase === 'assembling' ? 85 :
+                        Math.round((progress.clipsCompleted / progress.clipsTotal) * 80)}%`,
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Retry banner for failed productions */}
+        {production.status === 'failed' && (
+          <div className="px-6 py-3 bg-red-50 border-b border-red-200 flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <AlertTriangle size={16} className="text-red-600" />
+              <span className="text-sm text-red-800">This production failed.</span>
+            </div>
+            <button
+              onClick={handleRetry}
+              disabled={retrying}
+              className="flex items-center gap-1.5 px-3 py-1.5 text-sm bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors disabled:opacity-50"
+            >
+              {retrying ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <RotateCcw size={14} />
+              )}
+              {retrying ? 'Retrying...' : 'Retry'}
+            </button>
+          </div>
+        )}
 
         {/* Audio Player (for productions with media URL) */}
         {production.mediaUrl && (

--- a/src/hooks/useProductionProgress.js
+++ b/src/hooks/useProductionProgress.js
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { updateProductionProgress } from '../store/slices/producersSlice.js';
+import { tokenStorage } from '../services/tokenStorage';
+
+const API_URL = import.meta.env.VITE_AETHER_API_URL || `${window.location.origin}/api/v1`;
+const POLL_INTERVAL_MS = 3000;
+
+/**
+ * Custom hook that connects to the SSE endpoint for real-time production progress updates.
+ * Falls back to polling if SSE connection fails.
+ * Follows the same pattern as useCommentSSE.
+ */
+export function useProductionProgress(productionId, { enabled = true } = {}) {
+  const dispatch = useDispatch();
+  const eventSourceRef = useRef(null);
+  const pollIntervalRef = useRef(null);
+  const isPollingRef = useRef(false);
+
+  // Get current space context for query params (EventSource can't send custom headers)
+  const spaceType = useSelector(state => state.spaces?.currentSpace?.space_type || 'personal');
+  const spaceId = useSelector(state => state.spaces?.currentSpace?.space_id || '');
+
+  const buildQueryParams = useCallback(() => {
+    const params = new URLSearchParams();
+    const token = tokenStorage.getAccessToken();
+    if (token) params.set('token', token);
+    if (spaceType) params.set('space_type', spaceType);
+    if (spaceId) params.set('space_id', spaceId);
+    return params.toString();
+  }, [spaceType, spaceId]);
+
+  const stopPolling = useCallback(() => {
+    if (pollIntervalRef.current) {
+      clearInterval(pollIntervalRef.current);
+      pollIntervalRef.current = null;
+    }
+    isPollingRef.current = false;
+  }, []);
+
+  const startPolling = useCallback(() => {
+    if (isPollingRef.current || !productionId) return;
+    isPollingRef.current = true;
+
+    const poll = async () => {
+      try {
+        const token = tokenStorage.getAccessToken();
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+        if (spaceId) headers['X-Space-ID'] = spaceId;
+        if (spaceType) headers['X-Space-Type'] = spaceType;
+        const res = await fetch(`${API_URL}/productions/${productionId}/progress`, { headers });
+        if (res.ok) {
+          const data = await res.json();
+          dispatch(updateProductionProgress({ productionId, progress: data }));
+
+          // Stop polling if terminal state
+          if (data.phase === 'completed' || data.phase === 'failed') {
+            stopPolling();
+          }
+        }
+      } catch (err) {
+        // Ignore polling errors
+      }
+    };
+
+    poll(); // Initial fetch
+    pollIntervalRef.current = setInterval(poll, POLL_INTERVAL_MS);
+  }, [productionId, spaceId, spaceType, dispatch, stopPolling]);
+
+  useEffect(() => {
+    if (!productionId || !enabled) return;
+
+    const connect = () => {
+      const queryString = buildQueryParams();
+      const url = `${API_URL}/productions/${productionId}/progress/stream?${queryString}`;
+
+      const es = new EventSource(url);
+      eventSourceRef.current = es;
+
+      es.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          if (data.type === 'heartbeat') return;
+
+          // SSE events are wrapped as {production_id, state: {phase, clips_total, ...}}
+          // Normalize to flat format matching the polling endpoint
+          const progress = data.state ? { ...data.state } : data;
+
+          dispatch(updateProductionProgress({ productionId, progress }));
+
+          // Close SSE on terminal states
+          if (progress.phase === 'completed' || progress.phase === 'failed') {
+            es.close();
+            eventSourceRef.current = null;
+          }
+        } catch (err) {
+          // Ignore parse errors (heartbeats)
+        }
+      };
+
+      es.onerror = () => {
+        // SSE failed — fall back to polling
+        es.close();
+        eventSourceRef.current = null;
+        startPolling();
+      };
+    };
+
+    connect();
+
+    return () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      stopPolling();
+    };
+  }, [productionId, enabled, dispatch, startPolling, stopPolling, buildQueryParams]);
+}

--- a/src/store/slices/producersSlice.js
+++ b/src/store/slices/producersSlice.js
@@ -152,6 +152,27 @@ export const bulkDeleteProductions = createAsyncThunk(
 );
 
 /**
+ * Retry a failed production (republishes to Kafka job queue)
+ */
+export const retryProduction = createAsyncThunk(
+  'producers/retryProduction',
+  async ({ productionId, notebookId }, { rejectWithValue }) => {
+    try {
+      const response = await aetherApi.request(`/productions/${productionId}/retry`, {
+        method: 'POST',
+      });
+      if (response.success) {
+        return { productionId, notebookId, production: response.data };
+      } else {
+        return rejectWithValue(response.error || 'Failed to retry production');
+      }
+    } catch (error) {
+      return rejectWithValue(error.message || 'Failed to retry production');
+    }
+  }
+);
+
+/**
  * Fetch producer preferences for current user
  */
 export const fetchProducerPreferences = createAsyncThunk(
@@ -224,6 +245,9 @@ const initialState = {
   // Production content cache
   productionContent: {}, // { [productionId]: { content: string, loading: false, error: null } }
 
+  // Production progress (real-time updates from SSE/polling)
+  productionProgress: {}, // { [productionId]: { phase, clipsTotal, clipsCompleted, clipsFailed, message } }
+
   // Execution state
   executing: {
     isExecuting: false,
@@ -293,6 +317,43 @@ const producersSlice = createSlice({
       recent.unshift(agentId);
       // Keep only last 10 recent
       state.preferences.recent = recent.slice(0, 10);
+    },
+
+    // Update production progress from SSE/polling
+    updateProductionProgress: (state, action) => {
+      const { productionId, progress } = action.payload;
+      state.productionProgress[productionId] = {
+        phase: progress.phase,
+        clipsTotal: progress.clips_total || 0,
+        clipsCompleted: progress.clips_completed || 0,
+        clipsFailed: progress.clips_failed || 0,
+        message: progress.message || '',
+      };
+
+      // If completed or failed, update production status in notebook items
+      if (progress.phase === 'completed' || progress.phase === 'failed') {
+        for (const notebookId of Object.keys(state.productions)) {
+          const items = state.productions[notebookId]?.items;
+          if (items) {
+            const idx = items.findIndex(p => p.id === productionId);
+            if (idx !== -1) {
+              items[idx] = {
+                ...items[idx],
+                status: progress.phase,
+                mediaUrl: progress.media_url || items[idx].mediaUrl,
+                progressPhase: progress.phase,
+              };
+              break;
+            }
+          }
+        }
+      }
+    },
+
+    // Clear production progress
+    clearProductionProgress: (state, action) => {
+      const { productionId } = action.payload;
+      delete state.productionProgress[productionId];
     },
 
     // Set custom producer order (for drag-and-drop reordering)
@@ -550,6 +611,28 @@ const producersSlice = createSlice({
       });
 
     // =====================
+    // Retry Production
+    // =====================
+    builder
+      .addCase(retryProduction.fulfilled, (state, action) => {
+        const { productionId, notebookId, production } = action.payload;
+        // Update production status in notebook items
+        if (state.productions[notebookId]) {
+          const idx = state.productions[notebookId].items.findIndex(p => p.id === productionId);
+          if (idx !== -1) {
+            state.productions[notebookId].items[idx] = {
+              ...state.productions[notebookId].items[idx],
+              ...production,
+              status: 'queued',
+              progressPhase: '',
+            };
+          }
+        }
+        // Clear old progress
+        delete state.productionProgress[productionId];
+      });
+
+    // =====================
     // Fetch Producer Preferences
     // =====================
     builder
@@ -605,6 +688,8 @@ export const {
   clearProductionContent,
   addToRecent,
   setProducerOrder,
+  updateProductionProgress,
+  clearProductionProgress,
 } = producersSlice.actions;
 
 // =====================
@@ -636,6 +721,12 @@ export const selectNotebookProductions = createSelector(
 export const selectProductionContent = createSelector(
   [selectProducersState, (_, productionId) => productionId],
   (state, productionId) => state.productionContent[productionId]?.content || null
+);
+
+// Select production progress
+export const selectProductionProgress = createSelector(
+  [selectProducersState, (_, productionId) => productionId],
+  (state, productionId) => state.productionProgress[productionId] || null
 );
 
 // Select execution state


### PR DESCRIPTION
## Summary
- Add useProductionProgress hook with SSE streaming and polling fallback for real-time progress
- Fix SSE event format normalization so progress bar, status, and media URL update without page refresh
- Add topics textarea to podcast config for guiding content focus
- Fix modal overflow with scrollable content area

## Test plan
- [x] Verified progress bar reaches 100% on podcast completion (was stuck at ~80%)
- [x] Verified audio player appears immediately via SSE media_url (no page refresh needed)
- [x] Verified topics field sends context.topics to backend
- [x] Verified modal scrolls on small screens with many voice mapping fields
- [x] Deployed to K8s cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)