### PR TITLE
fix: auto-poll production status for in-progress jobs

### DIFF
--- a/src/components/notebooks/ProductionsList.jsx
+++ b/src/components/notebooks/ProductionsList.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useRef } from 'react';
 import { useAppSelector, useAppDispatch } from '../../store/index.js';
 import {
   fetchNotebookProductions,
@@ -56,6 +56,26 @@ const ProductionsList = ({
       dispatch(fetchNotebookProductions({ notebookId, limit: 20, offset: 0 }));
     }
   }, [dispatch, notebookId]);
+
+  // Poll for updates while any production is in-progress
+  const pollRef = useRef(null);
+  const hasInProgress = productions.some(p =>
+    p.status === 'processing' || p.status === 'queued' || p.status === 'rendering' || p.status === 'retrying'
+  );
+
+  useEffect(() => {
+    if (hasInProgress && notebookId) {
+      pollRef.current = setInterval(() => {
+        dispatch(fetchNotebookProductions({ notebookId, limit: 20, offset: 0 }));
+      }, 5000);
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [hasInProgress, notebookId, dispatch]);
 
   // Filter out failed productions and sort by date (newest first)
   const sortedProductions = [...productions]

--- a/src/pages/ProductionsManagementPage.jsx
+++ b/src/pages/ProductionsManagementPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useState, useMemo, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useAppSelector, useAppDispatch } from '../store/index.js';
 import {
@@ -86,6 +86,26 @@ const ProductionsManagementPage = () => {
       console.warn('[ProductionsManagement] No notebookId provided');
     }
   }, [dispatch, notebookId]);
+
+  // Poll for updates while any production is in-progress
+  const pollRef = useRef(null);
+  const hasInProgress = productions.some(p =>
+    p.status === 'processing' || p.status === 'queued' || p.status === 'rendering' || p.status === 'retrying'
+  );
+
+  useEffect(() => {
+    if (hasInProgress && notebookId) {
+      pollRef.current = setInterval(() => {
+        dispatch(fetchNotebookProductions({ notebookId, limit: 100, offset: 0 }));
+      }, 5000);
+    }
+    return () => {
+      if (pollRef.current) {
+        clearInterval(pollRef.current);
+        pollRef.current = null;
+      }
+    };
+  }, [hasInProgress, notebookId, dispatch]);
 
   // Filtered and sorted productions
   const filteredProductions = useMemo(() => {


### PR DESCRIPTION
## Summary
- Add 5-second polling to `ProductionsList` and `ProductionsManagementPage` when any production has a non-terminal status (processing/queued/rendering/retrying)
- Polling stops automatically when all productions reach completed or failed state
- Previously, status only updated when opening the preview modal (which triggered SSE via `useProductionProgress` hook)

## Test plan
- [x] Verified production status updates in the sidebar list without opening preview
- [x] Polling starts only when in-progress productions exist
- [x] Polling stops when all productions complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)